### PR TITLE
Fixes for cancellation and refunds

### DIFF
--- a/lib/braspag-rest/payment.rb
+++ b/lib/braspag-rest/payment.rb
@@ -18,6 +18,7 @@ module BraspagRest
     property :proof_of_sale, from: 'ProofOfSale'
     property :reason_code, from: 'ReasonCode'
     property :reason_message, from: 'ReasonMessage'
+    property :voided_amount, from: 'VoidedAmount'
 
     coerce_key :credit_card, BraspagRest::CreditCard
 

--- a/lib/braspag-rest/request.rb
+++ b/lib/braspag-rest/request.rb
@@ -13,7 +13,7 @@ module BraspagRest
 
       def void(request_id, payment_id, amount)
         execute_braspag_request do
-          RestClient.put(void_url(payment_id), { Amount: amount }.to_json, default_headers.merge('RequestId' => request_id))
+          RestClient.put(void_url(payment_id, amount), nil, default_headers.merge('RequestId' => request_id))
         end
       end
 
@@ -49,8 +49,8 @@ module BraspagRest
         config.url + SALE_ENDPOINT
       end
 
-      def void_url(payment_id)
-        sale_url + payment_id.to_s + VOID_ENDPOINT
+      def void_url(payment_id, amount)
+        sale_url + payment_id.to_s + VOID_ENDPOINT + (amount ? "?amount=#{amount}" : '')
       end
 
       def search_sale_url(payment_id)

--- a/lib/braspag-rest/sale.rb
+++ b/lib/braspag-rest/sale.rb
@@ -34,12 +34,13 @@ module BraspagRest
       response = BraspagRest::Request.void(request_id, payment.id, amount)
 
       if response.success?
-        self.payment.initialize_attributes(response.parsed_body)
+        voided_amount = amount ? payment.voided_amount.to_i + amount : payment.amount
+        self.payment.initialize_attributes(voided_amount: voided_amount)
       else
         initialize_errors(response.parsed_body) and return false
       end
 
-      payment.cancelled?
+      response.success?
     end
 
     def capture(amount = nil)

--- a/lib/braspag-rest/sale.rb
+++ b/lib/braspag-rest/sale.rb
@@ -37,7 +37,7 @@ module BraspagRest
         voided_amount = amount ? payment.voided_amount.to_i + amount : payment.amount
         self.payment.initialize_attributes(voided_amount: voided_amount)
       else
-        initialize_errors(response.parsed_body) and return false
+        initialize_errors(response.parsed_body)
       end
 
       response.success?

--- a/lib/braspag-rest/sale.rb
+++ b/lib/braspag-rest/sale.rb
@@ -31,7 +31,7 @@ module BraspagRest
     end
 
     def cancel(amount = nil)
-      response = BraspagRest::Request.void(request_id, payment.id, (amount || payment.amount))
+      response = BraspagRest::Request.void(request_id, payment.id, amount)
 
       if response.success?
         self.payment.initialize_attributes(response.parsed_body)

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -76,9 +76,8 @@ describe BraspagRest::Request do
 
   describe '.void' do
     let(:payment_id) { '123456' }
-    let(:void_url) { config['url'] + '/v2/sales/' + payment_id + '/void' }
     let(:request_id) { '30000000-0000-0000-0000-000000000001' }
-    let(:amount) { 100 }
+    let(:amount) { nil }
 
     let(:headers) {
       {
@@ -90,13 +89,27 @@ describe BraspagRest::Request do
       }
     }
 
-    context 'when is a successful response' do
-      let(:gateway_response) { double(code: 200, body: '{}') }
+    context "when no amount is given" do
+      let(:void_url) { config['url'] + '/v2/sales/' + payment_id + '/void' }
 
-      it 'calls sale void with request_id and amount' do
-        expect(RestClient).to receive(:put).with(void_url, { Amount: amount }.to_json, headers)
+      it 'does not specify an amount to be voided' do
+        expect(RestClient).to receive(:put).with(void_url, nil, headers)
         described_class.void(request_id, payment_id, amount)
       end
+    end
+
+    context "when an amount is given" do
+      let(:void_url) { config['url'] + '/v2/sales/' + payment_id + "/void?amount=#{amount}" }
+      let(:amount) { 100 }
+
+      it 'includes specific amount to void in request' do
+        expect(RestClient).to receive(:put).with(void_url, nil, headers)
+        described_class.void(request_id, payment_id, amount)
+      end
+    end
+
+    context 'when is a successful response' do
+      let(:gateway_response) { double(code: 200, body: '{}') }
 
       it 'returns a braspag successful response' do
         allow(RestClient).to receive(:put).and_return(gateway_response)

--- a/spec/sale_spec.rb
+++ b/spec/sale_spec.rb
@@ -126,35 +126,53 @@ describe BraspagRest::Sale do
     subject(:sale) { BraspagRest::Sale.new(request_id: 'xxx-xxx-xxx', payment: { id: 123, amount: 1000 }) }
 
     context "when no amount is given" do
+      before do
+        allow(BraspagRest::Request).to receive(:void).with('xxx-xxx-xxx', 123, nil)
+          .and_return(double(success?: true, parsed_body: {}))
+      end
+
       it 'calls braspag gateway with request_id, payment_id and no payment amount' do
         expect(BraspagRest::Request).to receive(:void).with('xxx-xxx-xxx', 123, nil).and_return(double(success?: true, parsed_body: {}))
-
         sale.cancel
+      end
+
+      it "updates the sale's voided amount with the full transaction amount" do
+        sale.cancel
+        expect(sale.payment.voided_amount).to eq(1000)
+      end
+
+      it "reports success" do
+        expect(sale.cancel).to be_truthy
       end
     end
 
     context "when an amount is given" do
+      before do
+        allow(BraspagRest::Request).to receive(:void).with('xxx-xxx-xxx', 123, 500)
+          .and_return(double(success?: true, parsed_body: {}))
+      end
+
       it 'calls braspag gateway with request_id, payment_id and amount parameter' do
         expect(BraspagRest::Request).to receive(:void).with('xxx-xxx-xxx', 123, 500).and_return(double(success?: true, parsed_body: {}))
-
         sale.cancel(500)
       end
-    end
 
-    context 'when the gateway returns a successful response' do
-      let(:parsed_body) {
-        { 'Status' => 10 }
-      }
+      it "updates the sale's voided amount with the requested refund amount" do
+        sale.cancel(500)
+        expect(sale.payment.voided_amount).to eq(500)
+      end
 
-      let(:response) { double(success?: true, parsed_body: parsed_body) }
+      it "reports success" do
+        expect(sale.cancel(500)).to be_truthy
+      end
 
-      before { allow(BraspagRest::Request).to receive(:void).and_return(response) }
+      context "and some amount has already been refunded" do
+        before { sale.payment.voided_amount = 300 }
 
-      it 'returns true and fills the sale object with the return' do
-        expect(sale.cancel).to be_truthy
-        expect(sale.payment.status).to eq(10)
-        expect(sale.payment.id).to eq(123)
-        expect(sale.payment.amount).to eq(1000)
+        it "updates the sale's voided amount with the summed refund amount" do
+          sale.cancel(500)
+          expect(sale.payment.voided_amount).to eq(800)
+        end
       end
     end
 

--- a/spec/sale_spec.rb
+++ b/spec/sale_spec.rb
@@ -125,16 +125,20 @@ describe BraspagRest::Sale do
   describe '#cancel' do
     subject(:sale) { BraspagRest::Sale.new(request_id: 'xxx-xxx-xxx', payment: { id: 123, amount: 1000 }) }
 
-    it 'calls braspag gateway with request_id, payment_id and payment amount' do
-      expect(BraspagRest::Request).to receive(:void).with('xxx-xxx-xxx', 123, 1000).and_return(double(success?: true, parsed_body: {}))
+    context "when no amount is given" do
+      it 'calls braspag gateway with request_id, payment_id and no payment amount' do
+        expect(BraspagRest::Request).to receive(:void).with('xxx-xxx-xxx', 123, nil).and_return(double(success?: true, parsed_body: {}))
 
-      sale.cancel
+        sale.cancel
+      end
     end
 
-    it 'calls braspag gateway with request_id, payment_id and amount parameter if it is not nil' do
-      expect(BraspagRest::Request).to receive(:void).with('xxx-xxx-xxx', 123, 500).and_return(double(success?: true, parsed_body: {}))
+    context "when an amount is given" do
+      it 'calls braspag gateway with request_id, payment_id and amount parameter' do
+        expect(BraspagRest::Request).to receive(:void).with('xxx-xxx-xxx', 123, 500).and_return(double(success?: true, parsed_body: {}))
 
-      sale.cancel(500)
+        sale.cancel(500)
+      end
     end
 
     context 'when the gateway returns a successful response' do


### PR DESCRIPTION
This PR introduces the following changes:
  - Send the amount parameter correctly when partially voiding a transaction.
  - Correctly return whether the void request was accepted at `BraspagRest#cancel`.
  - Provided the amount already voided in a transaction.