### PR TITLE
Add support for boleto transactions

### DIFF
--- a/lib/braspag-rest/payment.rb
+++ b/lib/braspag-rest/payment.rb
@@ -22,6 +22,8 @@ module BraspagRest
 
     property :digitable_line, from: 'DigitableLine'
     property :barcode_number, from: 'BarCodeNumber'
+    property :expiration_date, from: 'ExpirationDate'
+    property :instructions, from: 'Instructions'
     property :printable_page_url, from: 'Url'
 
     coerce_key :credit_card, BraspagRest::CreditCard

--- a/lib/braspag-rest/payment.rb
+++ b/lib/braspag-rest/payment.rb
@@ -20,6 +20,10 @@ module BraspagRest
     property :reason_message, from: 'ReasonMessage'
     property :voided_amount, from: 'VoidedAmount'
 
+    property :digitable_line, from: 'DigitableLine'
+    property :barcode_number, from: 'BarCodeNumber'
+    property :printable_page_url, from: 'Url'
+
     coerce_key :credit_card, BraspagRest::CreditCard
 
     def authorized?

--- a/spec/payment_spec.rb
+++ b/spec/payment_spec.rb
@@ -1,36 +1,36 @@
 require 'spec_helper'
 
 describe BraspagRest::Payment do
-  let(:braspag_response) {
+  let(:credit_card_payment) {
     {
       'ReasonMessage' => 'Successful',
       'Interest' => 'ByMerchant',
       'Links' => [
-         {
-            'Href' => 'https=>//apiqueryhomolog.braspag.com.br/v2/sales/1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1',
-            'Method' => 'GET',
-            'Rel' => 'self'
-         },
-         {
-            'Method' => 'PUT',
-            'Href' => 'https=>//apihomolog.braspag.com.br/v2/sales/1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1/capture',
-            'Rel' => 'capture'
-         },
-         {
-            'Rel' => 'void',
-            'Href' => 'https=>//apihomolog.braspag.com.br/v2/sales/1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1/void',
-            'Method' => 'PUT'
-         }
+        {
+          'Href' => 'https=>//apiqueryhomolog.braspag.com.br/v2/sales/1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1',
+          'Method' => 'GET',
+          'Rel' => 'self'
+        },
+        {
+          'Method' => 'PUT',
+          'Href' => 'https=>//apihomolog.braspag.com.br/v2/sales/1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1/capture',
+          'Rel' => 'capture'
+        },
+        {
+          'Rel' => 'void',
+          'Href' => 'https=>//apihomolog.braspag.com.br/v2/sales/1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1/void',
+          'Method' => 'PUT'
+        }
       ],
       'ServiceTaxAmount' => 0,
       'Country' => 'BRA',
       'AcquirerTransactionId' => '0625101832104',
       'CreditCard' => {
-         'ExpirationDate' => '12/2021',
-         'SaveCard' => false,
-         'Brand' => 'Visa',
-         'CardNumber' => '000000******0001',
-         'Holder' => 'Teste Holder'
+        'ExpirationDate' => '12/2021',
+        'SaveCard' => false,
+        'Brand' => 'Visa',
+        'CardNumber' => '000000******0001',
+        'Holder' => 'Teste Holder'
       },
       'ReceivedDate' => '2015-06-25 10=>18=>32',
       'ProviderReturnCode' => '4',
@@ -51,8 +51,39 @@ describe BraspagRest::Payment do
     }
   }
 
+  let(:boleto_payment) {
+    {
+      'Address' => 'N/A, 1',
+      'Amount' => 1150,
+      'Assignor' => 'Desenvolvedores',
+      'BarCodeNumber' => '00093657200000011509999250000000000799999990',
+      'BoletoNumber' => '7-4',
+      'Country' => 'BRA',
+      'Currency' => 'BRL',
+      'Demostrative' => '',
+      'DigitableLine' => '00099.99921 50000.000005 07999.999902 3 65720000001150',
+      'ExpirationDate' => '2015-10-05',
+      'Identification' => 'N/A',
+      'Instructions' => 'N\u00e3o pagar este boleto. <br> Ele n\u00e3o ser\u00e1 conciliado.',
+      'Links' => [
+        {
+          'Href' => 'https://apiquerysandbox.braspag.com.br/v2/sales/795cc546-8d3c-4ff3-8548-77320fc4b595',
+          'Method' => 'GET',
+          'Rel' => 'self'
+        }
+      ],
+      'PaymentId' => '795cc546-8d3c-4ff3-8548-77320fc4b595',
+      'Provider' => 'Simulado',
+      'ReasonCode' => 0,
+      'ReceivedDate' => '2015-10-02 13:11:01',
+      'Status' => 1,
+      'Type' => 'Boleto',
+      'Url' => 'https://sandbox.pagador.com.br/post/pagador/reenvia.asp/795cc546-8d3c-4ff3-8548-77320fc4b595'
+    }
+  }
+
   describe '.new' do
-    subject(:payment) { BraspagRest::Payment.new(braspag_response) }
+    subject(:payment) { BraspagRest::Payment.new(credit_card_payment) }
 
     it 'initializes a payment using braspag response format' do
       expect(payment.type).to eq('CreditCard')
@@ -127,6 +158,16 @@ describe BraspagRest::Payment do
       it 'returns not cancelled' do
         expect(sale).not_to be_cancelled
       end
+    end
+  end
+
+  describe 'boleto payments' do
+    subject(:payment) { BraspagRest::Payment.new(boleto_payment) }
+
+    it 'features boleto-specific attributes' do
+      expect(payment.digitable_line).to eq('00099.99921 50000.000005 07999.999902 3 65720000001150')
+      expect(payment.barcode_number).to eq('00093657200000011509999250000000000799999990')
+      expect(payment.printable_page_url).to eq('https://sandbox.pagador.com.br/post/pagador/reenvia.asp/795cc546-8d3c-4ff3-8548-77320fc4b595')
     end
   end
 end

--- a/spec/payment_spec.rb
+++ b/spec/payment_spec.rb
@@ -64,7 +64,7 @@ describe BraspagRest::Payment do
       'DigitableLine' => '00099.99921 50000.000005 07999.999902 3 65720000001150',
       'ExpirationDate' => '2015-10-05',
       'Identification' => 'N/A',
-      'Instructions' => 'N\u00e3o pagar este boleto. <br> Ele n\u00e3o ser\u00e1 conciliado.',
+      'Instructions' => 'Não pagar após o vencimento.',
       'Links' => [
         {
           'Href' => 'https://apiquerysandbox.braspag.com.br/v2/sales/795cc546-8d3c-4ff3-8548-77320fc4b595',
@@ -167,6 +167,8 @@ describe BraspagRest::Payment do
     it 'features boleto-specific attributes' do
       expect(payment.digitable_line).to eq('00099.99921 50000.000005 07999.999902 3 65720000001150')
       expect(payment.barcode_number).to eq('00093657200000011509999250000000000799999990')
+      expect(payment.expiration_date).to eq('2015-10-05')
+      expect(payment.instructions).to eq('Não pagar após o vencimento.')
       expect(payment.printable_page_url).to eq('https://sandbox.pagador.com.br/post/pagador/reenvia.asp/795cc546-8d3c-4ff3-8548-77320fc4b595')
     end
   end


### PR DESCRIPTION
This PR adds the necessary fields to the `Payment` model in order to enable the creation of "boleto" transactions.