### PR TITLE
Add support for ERB blocks inside the configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,50 @@ Or install it yourself as:
 
 ## Usage
 
+### Configuration
+
+The gem looks for a default `config/braspag-rest.yml` configuration file, with
+environment (`RACK_ENV` or `RAILS_ENV`) settings for the Braspag API.
+
+```yml
+# config/braspag-rest.yml
+development:
+  url: 'https://apisandbox.braspag.com.br'
+  query_url: 'https://apiquerysandbox.braspag.com.br'
+  merchant_id: 'Your MerchantId here'
+  merchant_key: 'Your MerchantKey here'
+```
+
+If you want to use a different file or manually set which environment should be
+used, you can create an initializer file and use the `BraspagRest.config` method
+to set your config.
+
+```ruby
+# config/initializers/braspag-rest.rb
+BraspagRest.config do |config|
+  config.config_file_path = 'config/path/here.yml'
+  config.enviroment = 'production'
+end
+```
+
+You can use ERB blocks to interpolate values from your environment variables into
+the configuration if you are using something like [dotenv](https://github.com/bkeepers/dotenv)
+to handle configuration values that shouldn't be present in the source code.
+
+```yml
+# config/braspag-rest.yml
+development:
+  url: 'https://apisandbox.braspag.com.br'
+  query_url: 'https://apiquerysandbox.braspag.com.br'
+  merchant_id: 'Your MerchantId here'
+  merchant_key: 'Your MerchantKey here'
+production:
+  url: <%= ENV['BRASPAG_URL'] %>
+  query_url: <%= ENV['BRASPAG_QUERY_URL'] %>
+  merchant_id: <%= ENV['BRASPAG_MERCHANT_ID'] %>
+  merchant_key: <%= ENV['BRASPAG_MERCHANT_KEY'] %>
+```
+
 ### Authorize an order
 
 ```rb
@@ -97,4 +141,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/Dinda-
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/braspag-rest.rb
+++ b/lib/braspag-rest.rb
@@ -1,8 +1,8 @@
 module BraspagRest
   def self.config
-    yield BraspagRest::Configuration.instance if block_given?
-
-    BraspagRest::Configuration.instance
+    @config ||= BraspagRest::Configuration.new
+    yield @config if block_given?
+    @config
   end
 end
 

--- a/lib/braspag-rest/configuration.rb
+++ b/lib/braspag-rest/configuration.rb
@@ -3,8 +3,6 @@ require 'yaml'
 
 module BraspagRest
   class Configuration
-    include Singleton
-
     attr_accessor :environment, :logger, :config_file_path
 
     def config_file_path
@@ -38,7 +36,7 @@ module BraspagRest
     private
 
     def config
-      @config ||= YAML.load(File.read(config_file_path))[environment]
+      @config ||= YAML.load(ERB.new(File.read(config_file_path)).result)[environment]
     end
   end
 end

--- a/lib/braspag-rest/request.rb
+++ b/lib/braspag-rest/request.rb
@@ -82,7 +82,7 @@ module BraspagRest
       end
 
       def config
-        @config ||= BraspagRest::Configuration.instance
+        @config ||= BraspagRest.config
       end
     end
   end

--- a/spec/braspag_rest_spec.rb
+++ b/spec/braspag_rest_spec.rb
@@ -2,42 +2,13 @@ require 'spec_helper'
 
 describe BraspagRest do
   describe '.config' do
-    context 'when there is a block to configure the gem' do
-      subject(:configuration) { BraspagRest::Configuration.instance }
-
-      it 'configures the gem using values from configuration file' do
-        BraspagRest.config do |config|
-          config.config_file_path = 'spec/fixtures/configuration.yml'
-          config.environment = 'test'
-        end
-
-        expect(configuration.config_file_path).to eq('spec/fixtures/configuration.yml')
-        expect(configuration.environment).to eq('test')
-        expect(configuration.url).to eq('https://apisandbox.braspag.com.br')
-        expect(configuration.query_url).to eq('https://apiquerysandbox.braspag.com.br')
-        expect(configuration.merchant_id).to eq('12345678-1234-1234-1234-123456789012')
-        expect(configuration.merchant_key).to eq('1234567890123456789012345678901234567890')
-      end
-    end
-
-    context 'when there is no block to configure the gem' do
-      subject(:configuration) { BraspagRest::Configuration.clone.instance }
-
-      it 'returns a instance of braspag configuration with default config file path' do
-        expect(configuration.config_file_path).to eq('config/braspag-rest.yml')
+    it 'yields the current configuration object' do
+      yielded = nil
+      BraspagRest.config do |config|
+        yielded = config
       end
 
-      it 'sets RACK_ENV variable value as environment if is filled' do
-        ENV['RACK_ENV'] = 'production'
-        ENV['RAILS_ENV'] = nil
-        expect(configuration.environment).to eq('production')
-      end
-
-      it 'sets RAILS_ENV variable value as environment if is filled' do
-        ENV['RAILS_ENV'] = 'qa'
-        ENV['RACK_ENV'] = nil
-        expect(configuration.environment).to eq('qa')
-      end
+      expect(yielded).to eq(BraspagRest.config)
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe BraspagRest::Configuration do
+  context 'when there is custom configuration file and environment name' do
+    subject(:configuration) { BraspagRest::Configuration.new }
+
+    it 'configures the gem using values from configuration file' do
+      configuration.config_file_path = 'spec/fixtures/configuration.yml'
+      configuration.environment = 'test'
+
+      expect(configuration.config_file_path).to eq('spec/fixtures/configuration.yml')
+      expect(configuration.environment).to eq('test')
+      expect(configuration.url).to eq('https://apisandbox.braspag.com.br')
+      expect(configuration.query_url).to eq('https://apiquerysandbox.braspag.com.br')
+      expect(configuration.merchant_id).to eq('12345678-1234-1234-1234-123456789012')
+      expect(configuration.merchant_key).to eq('1234567890123456789012345678901234567890')
+    end
+  end
+
+  context 'default configuration' do
+    subject(:configuration) { BraspagRest::Configuration.new }
+
+    it 'returns a instance of braspag configuration with default config file path' do
+      expect(configuration.config_file_path).to eq('config/braspag-rest.yml')
+    end
+
+    it 'sets RACK_ENV variable value as environment if is filled' do
+      ENV['RACK_ENV'] = 'production'
+      ENV['RAILS_ENV'] = nil
+      expect(configuration.environment).to eq('production')
+    end
+
+    it 'sets RAILS_ENV variable value as environment if is filled' do
+      ENV['RAILS_ENV'] = 'qa'
+      ENV['RACK_ENV'] = nil
+      expect(configuration.environment).to eq('qa')
+    end
+  end
+
+  context 'when the config file has ERB blocks' do
+    subject(:configuration) { BraspagRest::Configuration.new }
+
+    it 'processes the ERB code before parsing the configuration' do
+      configuration.config_file_path = 'spec/fixtures/configuration.yml'
+      configuration.environment = 'production'
+
+      ENV['BRASPAG_MERCHANT_KEY'] = 'MERCHANT_KEY_SET_THROUGH_ENV'
+      expect(configuration.merchant_key).to eq('MERCHANT_KEY_SET_THROUGH_ENV')
+    end
+  end
+end

--- a/spec/fixtures/configuration.yml
+++ b/spec/fixtures/configuration.yml
@@ -4,3 +4,5 @@ test:
   merchant_id: "12345678-1234-1234-1234-123456789012"
   merchant_key: "1234567890123456789012345678901234567890"
   log_enable: true
+production:
+  merchant_key: <%= ENV["BRASPAG_MERCHANT_KEY"] %>


### PR DESCRIPTION
This is useful for applications that are using environment variables and
[dotenv](https://github.com/bkeepers/dotenv) to load different configuration values without touching the YAML
file.

This patch also expands the documentation of how to configure the gem in a
Rails app and removes the `Singleton` usage from the `Configuration` class to
simplify how the class is tested and to avoid leaking state between the multiple
test examples that assert operations inside a config object.