### PR TITLE
Add payment attribute 'CapturedAmount'

### DIFF
--- a/lib/braspag-rest/payment.rb
+++ b/lib/braspag-rest/payment.rb
@@ -9,6 +9,7 @@ module BraspagRest
     property :id, from: 'PaymentId'
     property :type, from: 'Type'
     property :amount, from: 'Amount'
+    property :captured_amount, from: 'CapturedAmount'
     property :status, from: 'Status'
     property :provider, from: 'Provider'
     property :installments, from: 'Installments'

--- a/spec/payment_spec.rb
+++ b/spec/payment_spec.rb
@@ -41,6 +41,7 @@ describe BraspagRest::Payment do
       'Currency' => 'BRL',
       'ProviderReturnMessage' => 'Operation Successful',
       'Amount' => 15700,
+      'CapturedAmount' => 15800,
       'Type' => 'CreditCard',
       'AuthorizationCode' => '058475',
       'PaymentId' => '1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1',
@@ -88,6 +89,7 @@ describe BraspagRest::Payment do
     it 'initializes a payment using braspag response format' do
       expect(payment.type).to eq('CreditCard')
       expect(payment.amount).to eq(15700)
+      expect(payment.captured_amount).to eq(15800)
       expect(payment.provider).to eq('Simulado')
       expect(payment.installments).to eq(1)
       expect(payment.credit_card).to be_an_instance_of(BraspagRest::CreditCard)


### PR DESCRIPTION
This PR adds the necessary field ```captured_amount``` to the Payment model in order to ensure the correct paid amount.
