### PR TITLE
Adding request timeout when making requests to Braspag Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ development:
   query_url: 'https://apiquerysandbox.braspag.com.br'
   merchant_id: 'Your MerchantId here'
   merchant_key: 'Your MerchantKey here'
+  request_timeout: 60
 ```
 
 If you want to use a different file or manually set which environment should be
@@ -59,11 +60,13 @@ development:
   query_url: 'https://apiquerysandbox.braspag.com.br'
   merchant_id: 'Your MerchantId here'
   merchant_key: 'Your MerchantKey here'
+  request_timeout: 60
 production:
   url: <%= ENV['BRASPAG_URL'] %>
   query_url: <%= ENV['BRASPAG_QUERY_URL'] %>
   merchant_id: <%= ENV['BRASPAG_MERCHANT_ID'] %>
   merchant_key: <%= ENV['BRASPAG_MERCHANT_KEY'] %>
+  request_timeout: <%= ENV['BRASPAG_REQUEST_TIMEOUT'] %>
 ```
 
 ### Authorize an order

--- a/lib/braspag-rest/configuration.rb
+++ b/lib/braspag-rest/configuration.rb
@@ -33,6 +33,10 @@ module BraspagRest
       config['merchant_key']
     end
 
+    def request_timeout
+      config.fetch('request_timeout', 60)
+    end
+
     private
 
     def config

--- a/spec/fixtures/configuration.yml
+++ b/spec/fixtures/configuration.yml
@@ -4,5 +4,6 @@ test:
   merchant_id: "12345678-1234-1234-1234-123456789012"
   merchant_key: "1234567890123456789012345678901234567890"
   log_enable: true
+  request_timeout: 60
 production:
   merchant_key: <%= ENV["BRASPAG_MERCHANT_KEY"] %>

--- a/spec/hashie/iutrash_spec.rb
+++ b/spec/hashie/iutrash_spec.rb
@@ -47,8 +47,8 @@ describe Hashie::IUTrash do
 
     it 'nested inverse attributes' do
       params['Telephones'] = [
-         { 'Code' => '+55', 'Number' => '555-555' },
-         { 'Code' => '+1', 'Number' => '222-222' }
+         { :code => '+55', :number => '555-555' },
+         { :code => '+1', :number => '222-222' }
       ]
       person = Person.new(params)
 

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -36,12 +36,18 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 200, body: '{}') }
 
       it 'calls sale creation with request_id and their parameters' do
-        expect(RestClient).to receive(:post).with(sale_url, params.to_json, headers)
+        expect(RestClient::Request).to receive(:execute).with(
+          method: :post,
+          url: sale_url,
+          payload: params.to_json,
+          headers: headers,
+          timeout: config['request_timeout']
+        )
         described_class.authorize(request_id, params)
       end
 
       it 'returns a braspag successful response' do
-        allow(RestClient).to receive(:post).and_return(gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_return(gateway_response)
 
         response = described_class.authorize(request_id, params)
         expect(response).to be_success
@@ -53,7 +59,7 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 400, body: '{}') }
 
       it 'returns a braspag unsuccessful response and log it as a warning' do
-        allow(RestClient).to receive(:post).and_raise(RestClient::ExceptionWithResponse, gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::ExceptionWithResponse, gateway_response)
         expect(logger).to receive(:warn).with("[BraspagRest][Error] message: RestClient::ExceptionWithResponse, status: 400, body: \"{}\"")
 
         response = described_class.authorize(request_id, params)
@@ -66,10 +72,19 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 500, body: '{}') }
 
       it 'raises the exception and log it as an error' do
-        allow(RestClient).to receive(:post).and_raise(RestClient::Exception, gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception, gateway_response)
         expect(logger).to receive(:error).with("[BraspagRest][Error] message: RestClient::Exception, status: 500, body: \"{}\"")
 
         expect { described_class.authorize(request_id, params) }.to raise_error(RestClient::Exception)
+      end
+    end
+
+    context 'when a timeout occurs' do
+      it 'raises the exception and log it as an error' do
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::RequestTimeout)
+        expect(logger).to receive(:error).with("[BraspagRest][Timeout] message: Request Timeout")
+
+        expect { described_class.authorize(request_id, params) }.to raise_error(RestClient::RequestTimeout)
       end
     end
   end
@@ -93,7 +108,12 @@ describe BraspagRest::Request do
       let(:void_url) { config['url'] + '/v2/sales/' + payment_id + '/void' }
 
       it 'does not specify an amount to be voided' do
-        expect(RestClient).to receive(:put).with(void_url, nil, headers)
+        expect(RestClient::Request).to receive(:execute).with(
+          method: :put,
+          url: void_url,
+          headers: headers,
+          timeout: config['request_timeout']
+        )
         described_class.void(request_id, payment_id, amount)
       end
     end
@@ -103,7 +123,12 @@ describe BraspagRest::Request do
       let(:amount) { 100 }
 
       it 'includes specific amount to void in request' do
-        expect(RestClient).to receive(:put).with(void_url, nil, headers)
+        expect(RestClient::Request).to receive(:execute).with(
+          method: :put,
+          url: void_url,
+          headers: headers,
+          timeout: config['request_timeout']
+        )
         described_class.void(request_id, payment_id, amount)
       end
     end
@@ -112,7 +137,7 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 200, body: '{}') }
 
       it 'returns a braspag successful response' do
-        allow(RestClient).to receive(:put).and_return(gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_return(gateway_response)
 
         response = described_class.void(request_id, payment_id, amount)
         expect(response).to be_success
@@ -124,7 +149,7 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 400, body: '{}') }
 
       it 'returns a braspag unsuccessful response and log it as a warning' do
-        allow(RestClient).to receive(:put).and_raise(RestClient::ExceptionWithResponse, gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::ExceptionWithResponse, gateway_response)
         expect(logger).to receive(:warn).with("[BraspagRest][Error] message: RestClient::ExceptionWithResponse, status: 400, body: \"{}\"")
 
         response = described_class.void(request_id, payment_id, amount)
@@ -137,10 +162,19 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 500, body: '{}') }
 
       it 'raises the exception and log it as an error' do
-        allow(RestClient).to receive(:put).and_raise(RestClient::Exception, gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception, gateway_response)
         expect(logger).to receive(:error).with("[BraspagRest][Error] message: RestClient::Exception, status: 500, body: \"{}\"")
 
         expect { described_class.void(request_id, payment_id, amount) }.to raise_error(RestClient::Exception)
+      end
+    end
+
+    context 'when a timeout occurs' do
+      it 'raises the exception and log it as an error' do
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::RequestTimeout)
+        expect(logger).to receive(:error).with("[BraspagRest][Timeout] message: Request Timeout")
+
+        expect { described_class.void(request_id, payment_id, amount) }.to raise_error(RestClient::RequestTimeout)
       end
     end
   end
@@ -164,12 +198,17 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 200, body: '{}') }
 
       it 'calls sale void with request_id and amount' do
-        expect(RestClient).to receive(:get).with(search_url, headers)
+        expect(RestClient::Request).to receive(:execute).with(
+          method: :get,
+          url: search_url,
+          headers: headers,
+          timeout: config['request_timeout']
+        )
         described_class.get_sale(request_id, payment_id)
       end
 
       it 'returns a braspag successful response' do
-        allow(RestClient).to receive(:get).and_return(gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_return(gateway_response)
 
         response = described_class.get_sale(request_id, payment_id)
         expect(response).to be_success
@@ -181,10 +220,19 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 404, body: '{}') }
 
       it 'raises the exception and log it as an error' do
-        allow(RestClient).to receive(:get).and_raise(RestClient::ResourceNotFound)
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::ResourceNotFound)
         expect(logger).to receive(:error).with("[BraspagRest][Error] message: Resource Not Found, status: , body: nil")
 
         expect { described_class.get_sale(request_id, payment_id) }.to raise_error(RestClient::ResourceNotFound)
+      end
+    end
+
+    context 'when a timeout occurs' do
+      it 'raises the exception and log it as an error' do
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::RequestTimeout)
+        expect(logger).to receive(:error).with("[BraspagRest][Timeout] message: Request Timeout")
+
+        expect { described_class.get_sale(request_id, payment_id) }.to raise_error(RestClient::RequestTimeout)
       end
     end
   end
@@ -209,12 +257,18 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 200, body: '{}') }
 
       it 'calls sale capture with request_id and amount' do
-        expect(RestClient).to receive(:put).with(capture_url, { Amount: amount }.to_json, headers)
+        expect(RestClient::Request).to receive(:execute).with(
+          method: :put,
+          url: capture_url,
+          payload: { Amount: amount }.to_json,
+          headers: headers,
+          timeout: config['request_timeout']
+        )
         described_class.capture(request_id, payment_id, amount)
       end
 
       it 'returns a braspag successful response' do
-        allow(RestClient).to receive(:put).and_return(gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_return(gateway_response)
 
         response = described_class.capture(request_id, payment_id, amount)
         expect(response).to be_success
@@ -226,7 +280,7 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 400, body: '{}') }
 
       it 'returns a braspag unsuccessful response and log it as a warning' do
-        allow(RestClient).to receive(:put).and_raise(RestClient::ExceptionWithResponse, gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::ExceptionWithResponse, gateway_response)
         expect(logger).to receive(:warn).with("[BraspagRest][Error] message: RestClient::ExceptionWithResponse, status: 400, body: \"{}\"")
 
         response = described_class.capture(request_id, payment_id, amount)
@@ -239,10 +293,19 @@ describe BraspagRest::Request do
       let(:gateway_response) { double(code: 500, body: '{}') }
 
       it 'raises the exception and log it as an error' do
-        allow(RestClient).to receive(:put).and_raise(RestClient::Exception, gateway_response)
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception, gateway_response)
         expect(logger).to receive(:error).with("[BraspagRest][Error] message: RestClient::Exception, status: 500, body: \"{}\"")
 
         expect { described_class.capture(request_id, payment_id, amount) }.to raise_error(RestClient::Exception)
+      end
+    end
+
+    context 'when a timeout occurs' do
+      it 'raises the exception and log it as an error' do
+        allow(RestClient::Request).to receive(:execute).and_raise(RestClient::RequestTimeout)
+        expect(logger).to receive(:error).with("[BraspagRest][Timeout] message: Request Timeout")
+
+        expect { described_class.capture(request_id, payment_id, amount) }.to raise_error(RestClient::RequestTimeout)
       end
     end
   end


### PR DESCRIPTION
This pull request has the goal to add timeout limits when making requests to Braspag gateway.
Having control over the timeout has the ability to have some fallback, process later with an async task or something like that giving more flexibility.

The timeout limit is set on configuration `yaml` file using the `request_timeout` key.
If a timeout occurs, it'll raise a `RestClient:RequestTimeout` exception and generating log if enable.
- Using `RestClient::Request.execute` instead of helper methods like `get` or `post` directly 
- Tests has been adjusted and added more.
