### PR TITLE
Find payments by merchant order id

### DIFF
--- a/lib/braspag-rest/request.rb
+++ b/lib/braspag-rest/request.rb
@@ -45,6 +45,19 @@ module BraspagRest
         end
       end
 
+      def get_sales_for_merchant_order_id(request_id, merchant_order_id)
+        config.logger.info("[BraspagRest][GetSale] endpoint: #{search_sales_for_merchant_order_id_url(merchant_order_id)}") if config.log_enabled?
+
+        execute_braspag_request do
+          RestClient::Request.execute(
+            method: :get,
+            url: search_sales_for_merchant_order_id_url(merchant_order_id),
+            headers: default_headers.merge('RequestId' => request_id),
+            timeout: config.request_timeout
+          )
+        end
+      end
+
       def capture(request_id, payment_id, amount)
         config.logger.info("[BraspagRest][Capture] endpoint: #{capture_url(payment_id)}, amount: #{amount}") if config.log_enabled?
 
@@ -95,6 +108,13 @@ module BraspagRest
 
       def capture_url(payment_id)
         sale_url + payment_id.to_s + CAPTURE_ENDPOINT
+      end
+
+      def search_sales_for_merchant_order_id_url(merchant_order_id)
+        url = URI.parse(config.query_url)
+        url.path = SALE_ENDPOINT
+        url.query = "merchantOrderId=#{merchant_order_id}"
+        url.to_s
       end
 
       def default_headers

--- a/lib/braspag-rest/sale.rb
+++ b/lib/braspag-rest/sale.rb
@@ -18,6 +18,13 @@ module BraspagRest
       new(response.parsed_body.merge('RequestId' => request_id))
     end
 
+    def self.find_by_order_id(request_id, order_id)
+      response = BraspagRest::Request.get_sales_for_merchant_order_id(request_id, order_id)
+      payments = response.parsed_body['Payments']
+
+      payments.map { |payment| BraspagRest::Sale.find(request_id, payment['PaymentId']) }
+    end
+
     def save
       response = BraspagRest::Request.authorize(request_id, inverse_attributes)
 

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -237,6 +237,32 @@ describe BraspagRest::Request do
     end
   end
 
+  describe '.get_sales_for_merchant_order_id' do
+    let(:logger) { double(info: nil) }
+    let(:request_id) { SecureRandom.uuid }
+    let(:transaction_id) { '1234567890' }
+
+    before do
+      allow(BraspagRest.config).to receive(:logger).and_return logger
+      allow(RestClient::Request).to receive(:execute)
+    end
+
+    it 'logs the requested url' do
+      expect(logger).to receive(:info).with("[BraspagRest][GetSale] endpoint: https://apiquerysandbox.braspag.com.br/v2/sales/?merchantOrderId=#{transaction_id}")
+      BraspagRest::Request.get_sales_for_merchant_order_id(request_id, transaction_id)
+    end
+
+    it 'request with the correct parameters' do
+      expect(RestClient::Request).to receive(:execute).with(
+        method: :get,
+        url: "https://apiquerysandbox.braspag.com.br/v2/sales/?merchantOrderId=#{transaction_id}",
+        headers: described_class.send(:default_headers).merge('RequestId' => request_id),
+        timeout: BraspagRest.config.request_timeout
+      )
+      BraspagRest::Request.get_sales_for_merchant_order_id(request_id, transaction_id)
+    end
+  end
+
   describe '.capture' do
     let(:payment_id) { '123456' }
     let(:capture_url) { config['url'] + '/v2/sales/' + payment_id + '/capture' }

--- a/spec/sale_spec.rb
+++ b/spec/sale_spec.rb
@@ -258,6 +258,31 @@ describe BraspagRest::Sale do
     end
   end
 
+  describe '.find_by_order_id' do
+    let(:request_id) { SecureRandom.uuid }
+    let(:order_id) { '1234567890' }
+
+    before do
+      allow(BraspagRest::Request).to receive(:get_sales_for_merchant_order_id).and_return(
+        double(parsed_body: { 'Payments' => [{ 'PaymentId' => '1234567'}] })
+      )
+
+      allow(BraspagRest::Sale).to receive(:find).and_return BraspagRest::Sale.new
+    end
+
+    subject { BraspagRest::Sale.find_by_order_id(request_id, order_id) }
+
+    it 'filters all sales for an order_id' do
+      expect(BraspagRest::Request).to receive(:get_sales_for_merchant_order_id).with(request_id, order_id)
+      subject
+    end
+
+    it 'return a list of BraspagRest::Sale' do
+      is_expected.to be_an Array
+      expect(subject.all? { |payment| payment.is_a?(BraspagRest::Sale) }).to be_truthy
+    end
+  end
+
   describe '#reload' do
     before { allow(BraspagRest::Request).to receive(:get_sale).and_return(double(parsed_body: braspag_response)) }
 


### PR DESCRIPTION
This PR adds new methods to filter payments using the MerchantOrderID trough the Braspag's API.
According to the Braspag's docs, it's not possible to find a payment by the MerchantOrderID but it is possible to get all the paymentIDs related to a MerchantOrderID.
Ref: http://apidocs.braspag.com.br/#Consultandoumavendapeloidentificadordaloja

#### Usage:
```
BraspagRest::Sale.find_by_order_id(SecureRandom.uuid, '{{merchant_order_id}}')
=> [#<BraspagRest::Sale>, #<BraspagRest::Sale>]
```