### PR TITLE
Fix bug when no result is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,15 @@ credit_card.saved = true
 ```rb
 sale = BraspagRest::Sale.find('REQUEST_ID', 'PAYMENT_ID')
 sale.customer.name
-=> Maria
+=> "Maria"
+```
+
+### Find sales for a store, aka: MerchantOrderId
+
+```rb
+sales = BraspagRest::Sale.find_by_order_id('REQUEST_ID', 'MERCHANT_ORDER_ID')
+sales.map { |sale| sale.customer.name }
+=> ["Maria", "Joana"]
 ```
 
 ### Cancel a sale

--- a/lib/braspag-rest/sale.rb
+++ b/lib/braspag-rest/sale.rb
@@ -22,7 +22,7 @@ module BraspagRest
       response = BraspagRest::Request.get_sales_for_merchant_order_id(request_id, order_id)
       payments = response.parsed_body['Payments']
 
-      payments.map { |payment| BraspagRest::Sale.find(request_id, payment['PaymentId']) }
+      Array(payments).map { |payment| BraspagRest::Sale.find(request_id, payment['PaymentId']) }
     end
 
     def save

--- a/spec/sale_spec.rb
+++ b/spec/sale_spec.rb
@@ -277,9 +277,22 @@ describe BraspagRest::Sale do
       subject
     end
 
-    it 'return a list of BraspagRest::Sale' do
+    it 'returns a list of BraspagRest::Sale' do
       is_expected.to be_an Array
       expect(subject.all? { |payment| payment.is_a?(BraspagRest::Sale) }).to be_truthy
+    end
+
+    context 'when no result is returned' do
+      before do
+        allow(BraspagRest::Request).to receive(:get_sales_for_merchant_order_id).and_return(
+          double(parsed_body: { 'Payments' => nil })
+        )
+      end
+
+      it 'returns an empty list' do
+        is_expected.to be_an Array
+        is_expected.to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
When the Braspag's search of payments by a MerchantOrderId returns nothing, the expected result for the key `Payments` is `nil` and not an empty list.
This PR fix the problema by wrapping up the result in an Array list.

```
BraspagRest::Sale.find_by_order_id(SecureRandom.uuid, 'an_invalid_order_id')
=> []
```